### PR TITLE
Download Functionality for Scan Results

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 UPLOAD_DIRECTORY="../common/Uploads"
-MONGODB_HOST="mongo-service"
+MONGODB_HOST="127.0.0.1"
 MONGODB_PORT=27017
 UTILITIES_PATH="../Utilities"
 REDIS_URL="redis://redis-service:6379"

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+# Prerequisites
+
+Please answer the following questions for yourself before submitting an issue. **YOU MAY DELETE THE PREREQUISITES SECTION.**
+
+- [ ] I am running the latest version
+- [ ] I checked the documentation and found no answer
+- [ ] I checked to make sure that this issue has not already been filed
+- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
+
+# Expected Behavior
+
+Please describe the behavior you are expecting
+
+# Current Behavior
+
+What is the current behavior?
+
+# Failure Information (for bugs)
+
+Please help provide information about the failure if this is a bug. If it is not a bug, please remove the rest of this template.
+
+## Steps to Reproduce
+
+Please provide detailed steps for reproducing the issue.
+
+1. step 1
+2. step 2
+3. you get it...
+
+## Context 
+**[THIS SECTION MAY BE DELETED IF IRREVELANT TO THE ISSUE]**
+
+Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.
+
+* Firmware Version:
+* Operating System:
+* SDK version:
+* Toolchain version:
+
+## Failure Logs
+
+Please include any relevant log snippets or files here.

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -11,32 +11,9 @@ Please answer the following questions for yourself before submitting an issue. *
 
 Please describe the behavior you are expecting
 
-# Current Behavior
+This pull request adds a new feature according to the issue to Scan8 that allows users to download completed scan results. The download button has been added to the "Completed Scans" section of the tool and works as expected.
 
 What is the current behavior?
 
-# Failure Information (for bugs)
+There is no download function in the "Completed Scans" section of the tool. So the users can not download the completed scan file results.
 
-Please help provide information about the failure if this is a bug. If it is not a bug, please remove the rest of this template.
-
-## Steps to Reproduce
-
-Please provide detailed steps for reproducing the issue.
-
-1. step 1
-2. step 2
-3. you get it...
-
-## Context 
-**[THIS SECTION MAY BE DELETED IF IRREVELANT TO THE ISSUE]**
-
-Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.
-
-* Firmware Version:
-* Operating System:
-* SDK version:
-* Toolchain version:
-
-## Failure Logs
-
-Please include any relevant log snippets or files here.

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# Testing
+
+The application comes with a test suite to help users ensure correct installation and help developers verify any updates. 
+
+The following tests should return **ok** status upon running the unit-test command `python3 app.py -v` from the `/Testing` directory.
+
+- [ ] `testResultsJSON`
+- [ ] `testResults`
+- [ ] `testUploads`
+- [ ] `testResultsDirectoryPresent`
+- [ ] `testUploadsDirectoryPresent`
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Fixes # (issue)
+This pull request adds a new feature according to the issue to Scan8 that allows users to download completed scan results. The download button has been added to the "Completed Scans" section of the tool and works as expected.
 
 
 ## Type of change

--- a/Coordinator/README.md
+++ b/Coordinator/README.md
@@ -1,2 +1,3 @@
-### Master Node
+### Coordinator Node
 
+The Coordinator Node listens to updates for new scans, subsequently creating and adding scan jobs to the Redis Queue.

--- a/Dashboard/README.md
+++ b/Dashboard/README.md
@@ -1,2 +1,3 @@
 ### Dashboard
 
+The Dashboard provides a responsive web interface for uploading files for new scans and tracking the status of all the submitted scans.

--- a/Dashboard/app.py
+++ b/Dashboard/app.py
@@ -1,9 +1,9 @@
-from flask import Flask, render_template, request, redirect, url_for, Response
+from flask import Flask, render_template, request, redirect, url_for, Response, send_file
 from datetime import datetime
 from werkzeug.utils import secure_filename
 import os
 import uuid
-from pymongo import MongoClient
+from pymongo import MongoClient, errors
 import json
 from hurry.filesize import size, si
 from dotenv import load_dotenv
@@ -12,6 +12,7 @@ load_dotenv()
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = os.getenv("UPLOAD_DIRECTORY")
+app.config['RESULTS_FOLDER'] = os.getenv("RESULTS_PATH")
 
 mongodbHost = os.getenv("MONGODB_HOST")
 mongodbPort = int(os.getenv("MONGODB_PORT"))
@@ -31,7 +32,8 @@ def index():
     queued = queuedScans.find()
     running = runningScans.find()
     completed = completedScans.find()
-    return render_template('index.html', prequeued=prequeued, queued=queued, running=running, completed=completed, newScanUrl=url_for('newScan'))
+    return render_template('index.html', prequeued=prequeued, queued=queued, running=running, completed=completed, 
+                           newScanUrl=url_for('newScan'),download_result=url_for('downloadResult', file='<file>'))
 
 
 def new_scan():
@@ -78,6 +80,14 @@ def progress():
 
     return Response(generate(), mimetype='text/event-stream')
 
+def download_result(file):
+    try:
+        file = completedScans.find_one({'_id': file})
+        if file:
+            filePath = app.config['RESULTS_FOLDER'] + "/" + file['_id'] + "/" + file['_id'] + ".json"
+            return send_file(filePath, as_attachment=True)      
+    except errors.OperationFailure as e:
+        return {"message": f"Error: {e}"}, 400
 
 app.add_url_rule("/", endpoint="dashboard", view_func=index, methods=['GET'])
 app.add_url_rule("/newScan", endpoint="newScan",
@@ -86,5 +96,7 @@ app.add_url_rule("/progress", endpoint="progress",
                  view_func=progress, methods=['GET'])
 app.add_url_rule("/upload", endpoint="upload",
                  view_func=upload_files, methods=['GET', 'POST'])
+app.add_url_rule("/downloadResult/<file>", endpoint="downloadResult",
+                 view_func=download_result, methods=['GET', 'POST'])
 if __name__ == "__main__":
     app.run(host="0.0.0.0",debug=True)

--- a/Dashboard/templates/index.html
+++ b/Dashboard/templates/index.html
@@ -100,6 +100,9 @@
                         <div id={{ item["_id"] }} class="progress-bar" style="width: 100%;"></div>
                     </div>
                 </div>
+                <form method="POST" action="{{ url_for('downloadResult', file=item['_id']) }}" style="margin-right: 10px;">
+                    <button type="submit" class="btn btn-primary btn-sm">Download</button>
+                </form>
             </div>
             {% endfor %}
         </div>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Scan8 (Open for GSoC 22)
+Scan8 (Open for GSoC and Hacktoberfest)
 ========
 
 Scan8 is a distributed scanning system for detecting trojans, viruses, malware, and other malicious threats embedded in files. The system will allow one to submit a list of URLs or files and get the scan results in return.  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Scan8
+Scan8 (Open for GSoC 22)
 ========
 
 Scan8 is a distributed scanning system for detecting trojans, viruses, malware, and other malicious threats embedded in files. The system will allow one to submit a list of URLs or files and get the scan results in return.  

--- a/Utilities/scanJob.py
+++ b/Utilities/scanJob.py
@@ -27,10 +27,22 @@ def scan(filePath):
         runningScans.insert_one(queued[0])
         queuedScans.delete_one({"_id": id})
     result = cd.scan(filePath)
-    filename = id+"_"+name+"_"+".json"
-    filename = resultsPath+"/"+filename
-    with open(filename, "a+") as file:
-        json.dump(result, file, indent=4)
+    dirPath = os.path.join(resultsPath, str(id))
+    if not os.path.exists(dirPath):
+        os.mkdir(dirPath)
+    filename = str(id)+".json"
+    filePath = dirPath + "/" + filename
+    with open(filePath, "a+") as file:
+        file.seek(0)
+        if os.path.getsize(filePath) == 0:
+            jsonData = []
+        else:
+            fileData = file.read()
+            jsonData = json.loads(fileData)
+        jsonData.append(result)
+        file.seek(0)
+        file.truncate()
+        json.dump(jsonData, file, indent=4)
     
     runningScans.update_one({"_id": id}, {'$inc': {'files.completed': 1}})
 

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -1,2 +1,3 @@
 ### Worker Node
 
+The Worker Node listens to updates for new jobs in Redis Queue and executes them.


### PR DESCRIPTION
This pull request adds a new feature according to the issue to Scan8 that allows users to download completed scan results. The download button has been added to the "Completed Scans" section of the tool and works as expected. 

Please review the changes made in this pull request and let me know if you have any feedback or concerns.

Screenshots:
Here are screenshots of the updated "Completed Scans" section showing the new download button:

![Screenshot 2023-03-21 132426](https://user-images.githubusercontent.com/65262773/226547753-8b7f6e35-33d5-4f6a-a423-01b32f15973a.png)

issue closes https://github.com/web-telescope/Scan8/issues/73